### PR TITLE
Bump runtime to 45

### DIFF
--- a/com.gigitux.youp.json
+++ b/com.gigitux.youp.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.gigitux.youp",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.38",
+  "runtime-version": "45",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
   "command": "youp",
@@ -24,6 +24,49 @@
   },
   "modules": [
     "shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json",
+    "shared-modules/libsoup/libsoup-2.4.json",
+    {
+        "name": "unifdef",
+        "no-autogen": true,
+        "make-install-args": [
+            "prefix=${FLATPAK_DEST}"
+        ],
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://dotat.at/prog/unifdef/unifdef-2.12.tar.xz",
+                "sha256": "43ce0f02ecdcdc723b2475575563ddb192e988c886d368260bc0a63aee3ac400"
+            }
+        ],
+        "cleanup": [ "*" ]
+    },
+    {
+        "name": "webkit2gtk-4.0",
+        "buildsystem": "cmake-ninja",
+        "config-opts": [
+            "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+            "-DPORT=GTK",
+            "-DENABLE_BUBBLEWRAP_SANDBOX=OFF",
+            "-DENABLE_DOCUMENTATION=OFF",
+            "-DUSE_SOUP2=ON",
+            "-DENABLE_MINIBROWSER=OFF",
+            "-DENABLE_WEBDRIVER=OFF",
+            "-DENABLE_GAMEPAD=OFF"
+        ],
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://webkitgtk.org/releases/webkitgtk-2.42.0.tar.xz",
+                "sha256": "828f95935861fae583fb8f2ae58cf64c63c178ae2b7c2d6f73070813ad64ed1b",
+                "x-checker-data": {
+                    "type": "html",
+                    "url": "https://webkitgtk.org/releases/",
+                    "version-pattern": "LATEST-STABLE-(\\d[\\.\\d]+\\d)",
+                    "url-template": "https://webkitgtk.org/releases/webkitgtk-$version.tar.xz"
+                }
+            }
+        ]
+    },
     {
       "name": "youp",
       "buildsystem": "meson",

--- a/com.gigitux.youp.json
+++ b/com.gigitux.youp.json
@@ -3,7 +3,10 @@
   "runtime": "org.gnome.Platform",
   "runtime-version": "45",
   "sdk": "org.gnome.Sdk",
-  "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.rust-stable",
+    "org.freedesktop.Sdk.Extension.llvm16"
+  ],
   "command": "youp",
   "finish-args": [
     "--share=ipc",
@@ -17,7 +20,8 @@
     "--talk-name=org.kde.StatusNotifierWatcher"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/rust-stable/bin",
+    "append-path": "/usr/lib/sdk/llvm16/bin:/usr/lib/sdk/rust-stable/bin",
+    "prepend-ld-library-path": "/usr/lib/sdk/llvm16/lib",
     "env": {
       "CARGO_HOME": "/run/build/youp/cargo"
     }


### PR DESCRIPTION
Add webkit2gtk-4.0 and libsoup2.4. Runtimes > 42 doesn't have webkit2gtk compiled with libsoup2.4

Closes https://github.com/flathub/com.gigitux.youp/issues/1

Let's see if it builds, last time I had several issues